### PR TITLE
`portfolio` 앱에 SiteHeader 컴포넌트 추가

### DIFF
--- a/apps/frontend-workshop/.storybook/main.ts
+++ b/apps/frontend-workshop/.storybook/main.ts
@@ -14,6 +14,7 @@ const config: StorybookConfig = {
     "../src/**/*.mdx",
     "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
     "../../../packages/react-ui/src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../../../apps/portfolio/**/*.stories.@(js|jsx|mjs|ts|tsx)",
   ],
   addons: [
     getAbsolutePath("@storybook/addon-essentials"),

--- a/apps/frontend-workshop/.storybook/preview.ts
+++ b/apps/frontend-workshop/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from "@storybook/react";
+import { breakpoints } from "@iamhoonse-js/react-ui/constants";
 import "@iamhoonse-js/react-ui/base.css";
 
 const preview: Preview = {
@@ -7,6 +8,47 @@ const preview: Preview = {
       matchers: {
         color: /(background|color)$/i,
         date: /Date$/i,
+      },
+    },
+
+    // 뷰포트 목록
+    viewport: {
+      viewports: {
+        tailwindSmall: {
+          name: "Tailwind Small",
+          styles: {
+            width: breakpoints.sm,
+            height: "100%",
+          },
+        },
+        tailwindMedium: {
+          name: "Tailwind Medium",
+          styles: {
+            width: breakpoints.md,
+            height: "100%",
+          },
+        },
+        tailwindLarge: {
+          name: "Tailwind Large",
+          styles: {
+            width: breakpoints.lg,
+            height: "100%",
+          },
+        },
+        tailwindXLarge: {
+          name: "Tailwind Extra Large",
+          styles: {
+            width: breakpoints.xl,
+            height: "100%",
+          },
+        },
+        tailwindXXLarge: {
+          name: "Tailwind 2XL",
+          styles: {
+            width: breakpoints["2xl"],
+            height: "100%",
+          },
+        },
       },
     },
 

--- a/apps/portfolio/containers/SiteHeader/index.spec.tsx
+++ b/apps/portfolio/containers/SiteHeader/index.spec.tsx
@@ -1,0 +1,11 @@
+import { describe, test, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SiteHeader from ".";
+
+describe("<SiteHeader/>", () => {
+  test("header 요소로 렌더링되어야 합니다.", () => {
+    render(<SiteHeader />);
+    const header = screen.getByRole("banner");
+    expect(header).toBeInTheDocument();
+  });
+});

--- a/apps/portfolio/containers/SiteHeader/index.stories.tsx
+++ b/apps/portfolio/containers/SiteHeader/index.stories.tsx
@@ -14,6 +14,9 @@ type Story = StoryObj<typeof meta>;
  * 전체 너비의 헤더 컴포넌트입니다.
  */
 export const Default: Story = {
+  parameters: {
+    viewport: { defaultViewport: "responsive" },
+  },
   args: {},
 };
 
@@ -52,7 +55,7 @@ export const Large: Story = {
  */
 export const XLarge: Story = {
   parameters: {
-    viewport: { defaultViewport: "tailwindExtraLarge" },
+    viewport: { defaultViewport: "tailwindXLarge" },
   },
   args: {},
 };
@@ -62,7 +65,7 @@ export const XLarge: Story = {
  */
 export const XXLarge: Story = {
   parameters: {
-    viewport: { defaultViewport: "tailwindSmall" },
+    viewport: { defaultViewport: "tailwindXXLarge" },
   },
   args: {},
 };

--- a/apps/portfolio/containers/SiteHeader/index.stories.tsx
+++ b/apps/portfolio/containers/SiteHeader/index.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import SiteHeader from ".";
+
+const meta = {
+  title: "portfolio/SiteHeader",
+  component: SiteHeader,
+  tags: ["autodocs"],
+} satisfies Meta<typeof SiteHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * 전체 너비의 헤더 컴포넌트입니다.
+ */
+export const Default: Story = {
+  args: {},
+};
+
+/**
+ * 헤더 컴포넌트의 작은 화면 크기에서의 예시입니다.
+ */
+export const Small: Story = {
+  parameters: {
+    viewport: { defaultViewport: "tailwindSmall" },
+  },
+  args: {},
+};
+
+/**
+ * 헤더 컴포넌트의 중간 화면 크기에서의 예시입니다.
+ */
+export const Medium: Story = {
+  parameters: {
+    viewport: { defaultViewport: "tailwindMedium" },
+  },
+  args: {},
+};
+
+/**
+ * 헤더 컴포넌트의 큰 화면 크기에서의 예시입니다.
+ */
+export const Large: Story = {
+  parameters: {
+    viewport: { defaultViewport: "tailwindLarge" },
+  },
+  args: {},
+};
+
+/**
+ * 헤더 컴포넌트의 매우 큰 화면 크기에서의 예시입니다.
+ */
+export const XLarge: Story = {
+  parameters: {
+    viewport: { defaultViewport: "tailwindExtraLarge" },
+  },
+  args: {},
+};
+
+/**
+ * 헤더 컴포넌트의 2XL 화면 크기에서의 예시입니다.
+ */
+export const XXLarge: Story = {
+  parameters: {
+    viewport: { defaultViewport: "tailwindSmall" },
+  },
+  args: {},
+};

--- a/apps/portfolio/containers/SiteHeader/index.tsx
+++ b/apps/portfolio/containers/SiteHeader/index.tsx
@@ -1,0 +1,9 @@
+import type { FC } from "react";
+
+/**
+ * 사이트의 헤더를 나타냅니다.
+ */
+const SiteHeader: FC = () => {
+  return <header>Header</header>;
+};
+export default SiteHeader;

--- a/apps/portfolio/package.json
+++ b/apps/portfolio/package.json
@@ -28,6 +28,7 @@
     "@iamhoonse-js/eslint-config": "workspace:*",
     "@iamhoonse-js/typescript-config": "workspace:*",
     "@iamhoonse-js/vitest-config": "workspace:*",
+    "@storybook/react": "^8.6.12",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -47,6 +47,11 @@
       "import": "./dist/components/index.es.js",
       "require": "./dist/components/index.cjs.js"
     },
+    "./constants": {
+      "types": "./dist/constants/index.d.ts",
+      "import": "./dist/constants/index.es.js",
+      "require": "./dist/constants/index.cjs.js"
+    },
     "./base.css": "./dist/styles/base.css"
   },
   "files": [

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -74,7 +74,7 @@
     "@iamhoonse-js/helpers": "workspace:*",
     "@iamhoonse-js/typescript-config": "workspace:*",
     "@iamhoonse-js/vitest-config": "workspace:*",
-    "@storybook/react": "^8.6.11",
+    "@storybook/react": "^8.6.12",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/packages/react-ui/src/constants/breakpoints/index.ts
+++ b/packages/react-ui/src/constants/breakpoints/index.ts
@@ -1,0 +1,3 @@
+import defaultTheme from "tailwindcss/defaultTheme";
+
+export default defaultTheme.screens;

--- a/packages/react-ui/src/constants/index.ts
+++ b/packages/react-ui/src/constants/index.ts
@@ -1,0 +1,6 @@
+/* v8 ignore start */
+
+/* breakpoints */
+export { default as breakpoints } from "@/constants/breakpoints";
+
+/* v8 ignore stop */

--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -27,6 +27,8 @@ const fileName: Exclude<LibraryOptions["fileName"], string> = (
       return `components/index.${format}.js`;
     case "styles":
       return `styles/index.${format}.js`;
+    case "constants":
+      return `constants/index.${format}.js`;
     default:
       return `${entryName}/index.${format}.js`;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       '@iamhoonse-js/vitest-config':
         specifier: workspace:*
         version: link:../../configs/vitest-config
+      '@storybook/react':
+        specifier: ^8.6.12
+        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.2)
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0
@@ -8796,6 +8799,21 @@ snapshots:
     optionalDependencies:
       '@storybook/test': 8.6.12(storybook@8.6.12(prettier@3.5.3))
       typescript: 5.7.3
+
+  '@storybook/react@8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.2)':
+    dependencies:
+      '@storybook/components': 8.6.12(storybook@8.6.12(prettier@3.5.3))
+      '@storybook/global': 5.0.0
+      '@storybook/manager-api': 8.6.12(storybook@8.6.12(prettier@3.5.3))
+      '@storybook/preview-api': 8.6.12(storybook@8.6.12(prettier@3.5.3))
+      '@storybook/react-dom-shim': 8.6.12(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.12(prettier@3.5.3))
+      '@storybook/theming': 8.6.12(storybook@8.6.12(prettier@3.5.3))
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      storybook: 8.6.12(prettier@3.5.3)
+    optionalDependencies:
+      '@storybook/test': 8.6.12(storybook@8.6.12(prettier@3.5.3))
+      typescript: 5.8.2
 
   '@storybook/test-runner@0.22.0(@swc/helpers@0.5.15)(@types/node@22.13.10)(storybook@8.6.12(prettier@3.5.3))(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.7.3))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -627,8 +627,8 @@ importers:
         specifier: workspace:*
         version: link:../../configs/vitest-config
       '@storybook/react':
-        specifier: ^8.6.11
-        version: 8.6.11(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.2)
+        specifier: ^8.6.12
+        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.2)
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0
@@ -2151,11 +2151,6 @@ packages:
       storybook: ^8.6.12
       vite: ^4.0.0 || ^5.0.0 || ^6.0.0
 
-  '@storybook/components@8.6.11':
-    resolution: {integrity: sha512-+lHcwQsSO8usKTXIBBmgmRCAa0L+KQaLJ5ARqkRTm6OjzkVVS+EPnIgL4H1nqzbwiTVXxSSOwAk+rST83KICnA==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-
   '@storybook/components@8.6.12':
     resolution: {integrity: sha512-FiaE8xvCdvKC2arYusgtlDNZ77b8ysr8njAYQZwwaIHjy27TbR2tEpLDCmUwSbANNmivtc/xGEiDDwcNppMWlQ==}
     peerDependencies:
@@ -2207,18 +2202,8 @@ packages:
     peerDependencies:
       storybook: ^8.6.12
 
-  '@storybook/manager-api@8.6.11':
-    resolution: {integrity: sha512-U3ijEFX7B7wNYzFctmTIXOiN0zLlt8/9EHbZQUUrQ1pf7bQzADJCy63Y3B+kir8i+n3LsBWB42X2aSiT0lLaKQ==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-
   '@storybook/manager-api@8.6.12':
     resolution: {integrity: sha512-O0SpISeJLNTQvhSBOsWzzkCgs8vCjOq1578rwqHlC6jWWm4QmtfdyXqnv7rR1Hk08kQ+Dzqh0uhwHx0nfwy4nQ==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-
-  '@storybook/preview-api@8.6.11':
-    resolution: {integrity: sha512-NpSVJFa9MkPq3u/h+bvx+iSnm6OG6mMUzMgmY67mA0dgIgOWcaoP2Y7254SZlBeho97HCValTDKJyqZMwiVlyQ==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
@@ -2226,13 +2211,6 @@ packages:
     resolution: {integrity: sha512-84FE3Hrs0AYKHqpDZOwx1S/ffOfxBdL65lhCoeI8GoWwCkzwa9zEP3kvXBo/BnEDO7nAfxvMhjASTZXbKRJh5Q==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-
-  '@storybook/react-dom-shim@8.6.11':
-    resolution: {integrity: sha512-giwqwx0PO70SyqoZ25CBM2tpAjJX5sjPm7uWKknYcFGl3H2PYDqqnvH7NfEXENQMq5DpAJisCZ0KkRvNHzLV2w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^8.6.11
 
   '@storybook/react-dom-shim@8.6.12':
     resolution: {integrity: sha512-51QvoimkBzYs8s3rCYnY5h0cFqLz/Mh0vRcughwYaXckWzDBV8l67WBO5Xf5nBsukCbWyqBVPpEQLww8s7mrLA==}
@@ -2252,21 +2230,6 @@ packages:
       vite: ^4.0.0 || ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
       '@storybook/test':
-        optional: true
-
-  '@storybook/react@8.6.11':
-    resolution: {integrity: sha512-ZaE2IS5alauWxEvWo8LNEi27QxiRfJrfffDpQJIIvY4WnR+jzgLdtMOAVo/cSM9mJSRLESEYW57b0l7JdQGm1g==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      '@storybook/test': 8.6.11
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^8.6.11
-      typescript: '>= 4.2.x'
-    peerDependenciesMeta:
-      '@storybook/test':
-        optional: true
-      typescript:
         optional: true
 
   '@storybook/react@8.6.12':
@@ -2295,11 +2258,6 @@ packages:
     resolution: {integrity: sha512-0BK1Eg+VD0lNMB1BtxqHE3tP9FdkUmohtvWG7cq6lWvMrbCmAmh3VWai3RMCCDOukPFpjabOr8BBRLVvhNpv2w==}
     peerDependencies:
       storybook: ^8.6.12
-
-  '@storybook/theming@8.6.11':
-    resolution: {integrity: sha512-G7IK5P9gzofUjfYhMo9Pdgbqcr22eoKFLD808Q8RxJopDoypdZKg4tes2iD+6YnrtnHS0nEoP/soMmfFYl9FIw==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
   '@storybook/theming@8.6.12':
     resolution: {integrity: sha512-6VjZg8HJ2Op7+KV7ihJpYrDnFtd9D1jrQnUS8LckcpuBXrIEbaut5+34ObY8ssQnSqkk2GwIZBBBQYQBCVvkOw==}
@@ -8651,10 +8609,6 @@ snapshots:
       ts-dedent: 2.2.0
       vite: 6.3.4(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)
 
-  '@storybook/components@8.6.11(storybook@8.6.12(prettier@3.5.3))':
-    dependencies:
-      storybook: 8.6.12(prettier@3.5.3)
-
   '@storybook/components@8.6.12(storybook@8.6.12(prettier@3.5.3))':
     dependencies:
       storybook: 8.6.12(prettier@3.5.3)
@@ -8720,26 +8674,12 @@ snapshots:
       '@vitest/utils': 2.1.9
       storybook: 8.6.12(prettier@3.5.3)
 
-  '@storybook/manager-api@8.6.11(storybook@8.6.12(prettier@3.5.3))':
-    dependencies:
-      storybook: 8.6.12(prettier@3.5.3)
-
   '@storybook/manager-api@8.6.12(storybook@8.6.12(prettier@3.5.3))':
-    dependencies:
-      storybook: 8.6.12(prettier@3.5.3)
-
-  '@storybook/preview-api@8.6.11(storybook@8.6.12(prettier@3.5.3))':
     dependencies:
       storybook: 8.6.12(prettier@3.5.3)
 
   '@storybook/preview-api@8.6.12(storybook@8.6.12(prettier@3.5.3))':
     dependencies:
-      storybook: 8.6.12(prettier@3.5.3)
-
-  '@storybook/react-dom-shim@8.6.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.12(prettier@3.5.3))':
-    dependencies:
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
       storybook: 8.6.12(prettier@3.5.3)
 
   '@storybook/react-dom-shim@8.6.12(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.12(prettier@3.5.3))':
@@ -8769,21 +8709,6 @@ snapshots:
       - rollup
       - supports-color
       - typescript
-
-  '@storybook/react@8.6.11(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.2)':
-    dependencies:
-      '@storybook/components': 8.6.11(storybook@8.6.12(prettier@3.5.3))
-      '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.6.11(storybook@8.6.12(prettier@3.5.3))
-      '@storybook/preview-api': 8.6.11(storybook@8.6.12(prettier@3.5.3))
-      '@storybook/react-dom-shim': 8.6.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.12(prettier@3.5.3))
-      '@storybook/theming': 8.6.11(storybook@8.6.12(prettier@3.5.3))
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-      storybook: 8.6.12(prettier@3.5.3)
-    optionalDependencies:
-      '@storybook/test': 8.6.12(storybook@8.6.12(prettier@3.5.3))
-      typescript: 5.8.2
 
   '@storybook/react@8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.7.3)':
     dependencies:
@@ -8855,10 +8780,6 @@ snapshots:
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 8.6.12(prettier@3.5.3)
-
-  '@storybook/theming@8.6.11(storybook@8.6.12(prettier@3.5.3))':
-    dependencies:
       storybook: 8.6.12(prettier@3.5.3)
 
   '@storybook/theming@8.6.12(storybook@8.6.12(prettier@3.5.3))':


### PR DESCRIPTION
This pull request introduces several updates to enhance the Storybook configuration, add a new `SiteHeader` component to the portfolio app, and improve the `react-ui` package by exporting Tailwind breakpoints. Additionally, it updates dependencies to the latest versions. Below is a summary of the key changes:

### Storybook Enhancements
* Updated `main.ts` in the frontend workshop to include stories from the portfolio app (`apps/frontend-workshop/.storybook/main.ts`).
* Added custom viewport configurations for Tailwind breakpoints in the Storybook preview (`apps/frontend-workshop/.storybook/preview.ts`).
* Upgraded `@storybook/react` to version `8.6.12` across multiple files, including `package.json` and `pnpm-lock.yaml` (e.g., `apps/portfolio/package.json`, `pnpm-lock.yaml`). [[1]](diffhunk://#diff-a31f895b0076fdd38c163fd56c08d935b8b67862a96099e4628e3b1f695c9e93R31) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR210-R212)

### New `SiteHeader` Component
* Implemented a new `SiteHeader` component with a basic header structure (`apps/portfolio/containers/SiteHeader/index.tsx`).
* Added unit tests for the `SiteHeader` component using Vitest (`apps/portfolio/containers/SiteHeader/index.spec.tsx`).
* Created Storybook stories for the `SiteHeader` component, showcasing different viewport sizes (`apps/portfolio/containers/SiteHeader/index.stories.tsx`).

### `react-ui` Package Improvements
* Exported Tailwind breakpoints as constants from the `react-ui` package (`packages/react-ui/src/constants/breakpoints/index.ts`, `packages/react-ui/src/constants/index.ts`). [[1]](diffhunk://#diff-53ff5e724afb17a43b9ed62430e9a8259a0ab53813df24574f7ffbc7bce304e9R1-R3) [[2]](diffhunk://#diff-2f17b9c14846307a68395166a0a9445b4e88310d07dc402b79e5ca73e75fded3R1-R6)
* Updated the `exports` field in `package.json` to include the new `constants` entry (`packages/react-ui/package.json`).
* Adjusted the Vite configuration to handle the new `constants` entry (`packages/react-ui/vite.config.ts`).