### PR TITLE
`release.yml` 워크플로우에서 의존성 설치 후 build 명령어 실행 단계 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build Packages
+        run: pnpm run build
+
       - name: Create Release Pull Request
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
This pull request adds a step to the release workflow to ensure that packages are built before creating a release pull request.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R71-R73): Added a new job step named "Build Packages" to run `pnpm run build` after installing dependencies.