### PR TITLE
`publish-github-pages` 워크플로우에서 Repository variable 에 등록된 변수를 참조하기 위한 네임스페이스가 잘못된 부분 수정

### DIFF
--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           GISCUS_REPO: ${{ github.repository }}
           GISCUS_REPO_ID: ${{ github.repository_id }}
-          GISCUS_DISCUSSION_CATEGORY: ${{ variables.GISCUS_DISCUSSION_CATEGORY }}
+          GISCUS_DISCUSSION_CATEGORY: ${{ vars.GISCUS_DISCUSSION_CATEGORY }}
           GISCUS_DISCUSSION_CATEGORY_ID: ${{ secrets.GISCUS_DISCUSSION_CATEGORY_ID }}
 
       - name: Upload artifact


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/publish-github-pages.yml` file. The change updates the reference for the `GISCUS_DISCUSSION_CATEGORY` environment variable to use `${{ vars.GISCUS_DISCUSSION_CATEGORY }}` instead of `${{ variables.GISCUS_DISCUSSION_CATEGORY }}` for consistency with GitHub Actions syntax.