### PR TITLE
`publish-github-pages` 워크플로우에서 빌드 단계에 주입되는 환경변수가 잘못된 부분 수정

### DIFF
--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -83,7 +83,7 @@ jobs:
         run: pnpm run build --filter=docs
         env:
           GISCUS_REPO: ${{ github.repository }}
-          GISCUS_REPO_ID: ${{ github.repository_id }}
+          GISCUS_REPO_ID: ${{ secrets.GISCUS_REPO_ID }}
           GISCUS_DISCUSSION_CATEGORY: ${{ vars.GISCUS_DISCUSSION_CATEGORY }}
           GISCUS_DISCUSSION_CATEGORY_ID: ${{ secrets.GISCUS_DISCUSSION_CATEGORY_ID }}
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/publish-github-pages.yml` file. The change updates the `GISCUS_REPO_ID` environment variable to use a GitHub secret instead of the repository ID directly.