### PR TITLE
`publish-github-pages` 워크플로우에서 빌드 단계 전에 .env.local 파일을 동적으로 작성하는 단계 추가

### DIFF
--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Generate .env file for docs
         run: |
-          echo "GISCUS_REPO=${{ github.repository }}" >> apps/docs/.env.local
+          echo "GISCUS_REPO=${{ github.repository }}" > apps/docs/.env.local
           echo "GISCUS_REPO_ID=${{ secrets.GISCUS_REPO_ID }}" >> apps/docs/.env.local
           echo "GISCUS_DISCUSSION_CATEGORY=${{ vars.GISCUS_DISCUSSION_CATEGORY }}" >> apps/docs/.env.local
           echo "GISCUS_DISCUSSION_CATEGORY_ID=${{ secrets.GISCUS_DISCUSSION_CATEGORY_ID }}" >> apps/docs/.env.local

--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -79,13 +79,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Generate .env file for docs
+        run: |
+          echo "GISCUS_REPO=${{ github.repository }}" >> apps/docs/.env.local
+          echo "GISCUS_REPO_ID=${{ secrets.GISCUS_REPO_ID }}" >> apps/docs/.env.local
+          echo "GISCUS_DISCUSSION_CATEGORY=${{ vars.GISCUS_DISCUSSION_CATEGORY }}" >> apps/docs/.env.local
+          echo "GISCUS_DISCUSSION_CATEGORY_ID=${{ secrets.GISCUS_DISCUSSION_CATEGORY_ID }}" >> apps/docs/.env.local
+
       - name: Build docs app
         run: pnpm run build --filter=docs
-        env:
-          GISCUS_REPO: ${{ github.repository }}
-          GISCUS_REPO_ID: ${{ secrets.GISCUS_REPO_ID }}
-          GISCUS_DISCUSSION_CATEGORY: ${{ vars.GISCUS_DISCUSSION_CATEGORY }}
-          GISCUS_DISCUSSION_CATEGORY_ID: ${{ secrets.GISCUS_DISCUSSION_CATEGORY_ID }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This pull request updates the workflow configuration for publishing GitHub Pages by changing how environment variables are handled during the documentation build process.

Workflow configuration changes:

* [`.github/workflows/publish-github-pages.yml`](diffhunk://#diff-fb39062420648092562c971c10565e97dbe28839e1c8e82d58d01ad0a30fd636R82-L88): Replaced inline environment variables in the `Build docs app` step with a preceding step that generates a `.env.local` file containing the required variables (`GISCUS_REPO`, `GISCUS_REPO_ID`, `GISCUS_DISCUSSION_CATEGORY`, `GISCUS_DISCUSSION_CATEGORY_ID`). This simplifies the build step and centralizes environment variable management.