### PR TITLE
release 워크플로우가 간헐적으로 실패하는 문제 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "view-report": "turbo run view-report",
     "merge-json-reports": "turbo run merge-json-reports",
     "prepare": "husky",
-    "version-packages": "turbo run build lint test && changeset version",
-    "publish-packages": "turbo run build lint test && changeset version && changeset publish"
+    "version-packages": "turbo run lint test && changeset version",
+    "publish-packages": "turbo run lint test && changeset version && changeset publish"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.0",


### PR DESCRIPTION
This pull request makes a minor adjustment to the `package.json` file by modifying the `version-packages` and `publish-packages` scripts to remove the `build` step.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R21): Updated the `version-packages` and `publish-packages` scripts to exclude the `build` step, ensuring these scripts only run `lint`, `test`, and `changeset` commands.