### PR TITLE
`release` 워크플로우에서 version 및 publish 스크립트 내에서 lint, test 를 실행하지 않고 앞 단계에서 먼저 실행하도록 변경

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Build Packages
         run: pnpm run build
 
+      - name: Run Tests
+        run: pnpm run test
+
       - name: Create Release Pull Request
         uses: changesets/action@v1
         with:

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "view-report": "turbo run view-report",
     "merge-json-reports": "turbo run merge-json-reports",
     "prepare": "husky",
-    "version-packages": "turbo run lint test && changeset version",
-    "publish-packages": "turbo run lint test && changeset version && changeset publish"
+    "version-packages": "changeset version",
+    "publish-packages": "changeset version && changeset publish"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.0",


### PR DESCRIPTION
This pull request introduces improvements to the release workflow and updates the `package.json` scripts to streamline the development process. The most important changes include adding a test step to the release workflow and simplifying the `version-packages` and `publish-packages` scripts in `package.json`.

### Release Workflow Enhancements:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R74-R76): Added a new step to run tests (`pnpm run test`) in the release workflow to ensure package integrity before creating a release pull request.

### `package.json` Script Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R21): Simplified the `version-packages` and `publish-packages` scripts by removing redundant lint and test commands, relying on `changeset version` and `changeset publish` directly.